### PR TITLE
Golang version upgrade

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
   release:
     uses: itzg/github-workflows/.github/workflows/go-with-releaser-image.yml@main
     with:
-      go-version: "1.20.10"
+      go-version: "1.21.10"
     secrets:
       image-registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
       image-registry-password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,4 +14,4 @@ jobs:
   build:
     uses: itzg/github-workflows/.github/workflows/go-test.yml@main
     with:
-      go-version: "1.20.10"
+      go-version: "1.21.10"

--- a/go.mod
+++ b/go.mod
@@ -29,4 +29,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.20
+go 1.21


### PR DESCRIPTION
Fixing golang security vulns for stdlib v1.20.10 by upgrading to v1.21.10